### PR TITLE
🐛 fix(lib): It is found that GitHub Actions must still use the `Node …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,9 @@ jobs:
       - name: build
         run: pnpm build
 
-      # 自动发布
+      # 自动发布，仅在本项目中使用 `node dist/bin.js -r`，其他项目使用 `cvlar -r`
       - name: Auto Release
-        run: cvlar -r
+        run: node dist/bin.js -r
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
…Dist/bin.js -R` in this project